### PR TITLE
feat: add test to reproduce #605

### DIFF
--- a/src/server/__tests__/ssr.test.ts
+++ b/src/server/__tests__/ssr.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ */
+import {useState} from 'react'
+import {renderHook, act} from '..'
+
+// This verifies that renderHook can be called in
+// a SSR-like environment.
+describe('renderHook', () => {
+  function useLoading() {
+    if (typeof window !== 'undefined') {
+      const [loading, setLoading] = useState(false)
+      return {loading, setLoading}
+    }
+  }
+
+  test('should not throw in SSR environment', () => {
+    expect(() => renderHook(() => useLoading())).not.toThrowError(
+      'document is not defined',
+    )
+  })
+})

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -13,7 +13,7 @@ function createServerRenderer<TProps, TResult>(
 ) {
   let renderProps: TProps | undefined
   let container: HTMLDivElement | undefined
-  let serverOutput: string = ''
+  let serverOutput = ''
   const testHarness = createTestHarness(rendererProps, wrapper, false)
 
   return {
@@ -34,7 +34,7 @@ function createServerRenderer<TProps, TResult>(
         container = document.createElement('div')
         container.innerHTML = serverOutput
         act(() => {
-          ReactDOM.hydrate(testHarness(renderProps), container!)
+          ReactDOM.hydrate(testHarness(renderProps), container || null)
         })
       }
     },
@@ -49,7 +49,7 @@ function createServerRenderer<TProps, TResult>(
     unmount() {
       if (container) {
         act(() => {
-          ReactDOM.unmountComponentAtNode(container!)
+          container && ReactDOM.unmountComponentAtNode(container)
         })
       }
     },


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

This fixes a bug that assumes that tests don't run in SSR environments.

**Why**:

With frameworks like Next.js and Remix rendering components on the server, it's important that this library can mimic SSR environments as closely as possible.

**How**:

First by adding a test that reproduces the issue and then by moving [this logic](https://github.com/testing-library/react-hooks-testing-library/blob/ef1d731c2a0d7d78e3b33b183d5b5dd927785aae/src/server/pure.ts#L16) "into the hydrate function, so we reference document when they want it to render for real." (suggested by [mpeyper](https://github.com/mpeyper)).

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation."
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->